### PR TITLE
Replace CMD by ENTRYPOINT

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,4 +18,4 @@ ADD https://huggingface.co/brunopio/Llama3-8B-1.58-100B-tokens-GGUF/resolve/main
 
 RUN echo "2565559c82a1d03ecd1101f536c5e99418d07e55a88bd5e391ed734f6b3989ac Llama3-8B-1.58-100B-tokens-TQ2_0.gguf" | sha256sum -c
 
-CMD ["python3", "run_inference.py", "-m", "Llama3-8B-1.58-100B-tokens-TQ2_0.gguf", "-p", "The meaning of life is"]
+ENTRYPOINT ["python3", "run_inference.py", "-m", "Llama3-8B-1.58-100B-tokens-TQ2_0.gguf", "-p"]


### PR DESCRIPTION
I changed the last dockerfile directive from `CMD` to `ENTRYPOINT`, so it allows to run the prompt directly from command line like:

```
  docker run --rm DOCKER_IMAGE "Is a photon a wave or a particle?"
```